### PR TITLE
Compression optimization to reduce storage size.

### DIFF
--- a/test.py
+++ b/test.py
@@ -46,7 +46,7 @@ class Testvideo2tfrecord(unittest.TestCase):
   #                    get_number_of_records(filenames, n_frames))
 
 
-def read_and_decode(filename_queue, n_frames):
+def read_and_decode(filename_queue, n_frames, jpeg_encode):
   """Creates one image sequence"""
 
   reader = tf.TFRecordReader()
@@ -69,7 +69,10 @@ def read_and_decode(filename_queue, n_frames):
                                        features=feature_dict)
 
     image_buffer = tf.reshape(features[path], shape=[])
-    image = tf.decode_raw(image_buffer, tf.uint8)
+    if jpeg_encode:
+      image = tf.image.decode_jpeg(image_buffer, channels=3)
+    else:
+      image = tf.decode_raw(image_buffer, tf.uint8)
     image = tf.reshape(image, tf.stack([height, width, num_depth]))
     image = tf.reshape(image, [1, height, width, num_depth])
     image_seq.append(image)
@@ -79,7 +82,7 @@ def read_and_decode(filename_queue, n_frames):
   return image_seq
 
 
-def get_number_of_records(filenames, n_frames):
+def get_number_of_records(filenames, n_frames, jpeg_encode=True):
   """
   this function determines the number of videos available in all tfrecord files. It also checks on the correct shape of the single examples in the tfrecord
   files.
@@ -97,7 +100,7 @@ def get_number_of_records(filenames, n_frames):
   # create new session to determine batch_size for validation/test data
   with tf.Session() as sess_valid:
     filename_queue_val = tf.train.string_input_producer(filenames, num_epochs=1)
-    image_seq_tensor_val = read_and_decode(filename_queue_val, n_frames)
+    image_seq_tensor_val = read_and_decode(filename_queue_val, n_frames, jpeg_encode)
 
     init_op = tf.group(tf.global_variables_initializer(),
                        tf.local_variables_initializer())


### PR DESCRIPTION
This PR closes #39 where the main idea is to try to reduce TFRecord size. 

I added a hyperparameter called "jpeg_encode" that is true by default, once I believe that the user may want to run this script with this configuration. Based on this, we set the encoding type to jpeg instead of transforming the image into a simple string, which uses a lot of storage space. 

Besides that, I also added verification of the TensorFlow version, to avoid errors when using TF > 2.

The jpeg decoder was also added into the test file to allow the user to decode the image correctly, in the case of jpeg encode.

Finally, there's an important point that I would like to talk about. I realized that you use the Numpy arrays of type "uint32". I would like to know more about this choice because the "uint8" type is enough to store images (where the value is between 0 and 255) and this kind of array is smaller than the other one, which occupies less memory and storage. 

So, do you think that we could change the type of the array? Or the "uint32" is important for some reason? Thank you.